### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,35 @@
-language: haskell
+env:
+  - CABALVER=1.16 GHCVER=7.6.3 SODIUMVER=1.0.2
+  - CABALVER=1.18 GHCVER=7.8.4 SODIUMVER=1.0.2
+  - CABALVER=1.22 GHCVER=7.10.1 SODIUMVER=1.0.2
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - env: CABALVER=1.16 GHCVER=7.6.3 SODIUMVER=1.0.2
+  - env: CABALVER=1.22 GHCVER=7.10.1 SODIUMVER=1.0.2
+
 before_install:
-  - wget http://download.dnscrypt.org/libsodium/releases/libsodium-0.4.1.tar.gz
-  - tar xf libsodium-0.4.1.tar.gz 
-  - cd libsodium-0.4.1
-  - ./autogen.sh
-  - ./configure && make check
-  - sudo make install
-  - sudo ldconfig
-  - cd ..
+  - curl -# -L https://github.com/jedisct1/libsodium/releases/download/$SODIUMVER/libsodium-$SODIUMVER.tar.gz | tar xzf -
+  - (cd libsodium-$SODIUMVER && ./autogen.sh && ./configure && make check && sudo make install && sudo ldconfig)
+  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+
 install:
-  - cabal install --only-dependencies --enable-tests
-  - cabal configure --enable-tests
-  - cabal build
+  - travis_retry cabal update
+  - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
 script:
+  - cabal configure --enable-tests --enable-benchmarks -v2
+
+  - cabal build
+  - cabal haddock
   - cabal test --show-details=always
+
+  - cabal check
+  - cabal sdist && cabal install --force-reinstalls dist/saltine-*.tar.gz
+
 notifications:
   email: true

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ and [`Crypto.Saltine.Core.Box`](https://github.com/tel/saltine/blob/master/src/C
 If you can think of ways to use Haskell's type system to enforce 
 security invariants, please suggest them.
 
-Tested with [`libsodium-4.1`](http://download.dnscrypt.org/libsodium/releases/).
+Tested with [`libsodium-1.0.2`](http://download.dnscrypt.org/libsodium/releases/).
 
 Inspired by @thoughtpolice's
 [`salt`](http://github.com/thoughtpolice/salt) library. `salt` also

--- a/saltine.cabal
+++ b/saltine.cabal
@@ -27,7 +27,7 @@ copyright:           Copyright (c) Joseph Abrahamson 2013
 category:            Cryptography
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==7.6.3
+tested-with:         GHC==7.6.3, GHC==7.8.4
 
 source-repository head
   type: git


### PR DESCRIPTION
- Test against libsodium 1.0.2 and add libsodium version to the
  build matrix
- Test against GHC 7.8.4, 7.6.3, and 7.10, allowing the
  latter two to fail.