### PR TITLE
Add a utils modules w/ randomVector

### DIFF
--- a/saltine.cabal
+++ b/saltine.cabal
@@ -46,6 +46,7 @@ library
                   Crypto.Saltine.Core.Sign
                   Crypto.Saltine.Core.Hash
                   Crypto.Saltine.Core.ScalarMult
+                  Crypto.Saltine.Core.Utils
                   Crypto.Saltine.Class
   other-modules:
                 Crypto.Saltine.Internal.Util

--- a/src/Crypto/Saltine/Core/Utils.hs
+++ b/src/Crypto/Saltine/Core/Utils.hs
@@ -1,0 +1,5 @@
+module Crypto.Saltine.Core.Utils
+    (Crypto.Saltine.Internal.Util.randomVector
+    ) where
+
+import qualified Crypto.Saltine.Internal.Util


### PR DESCRIPTION
It is reasonable to claim this should be `.Random` and produce
`Vector` instead of `ByteString` - the API at this point is arbitrary.

Fixes #35 ... if that is desired.  I expect to discuss/iterate on this patch so no pressure to accept as is.