### PR TITLE
Feature/secretbox detached

### DIFF
--- a/saltine.cabal
+++ b/saltine.cabal
@@ -46,6 +46,7 @@ library
                   Crypto.Saltine.Core.Sign
                   Crypto.Saltine.Core.Hash
                   Crypto.Saltine.Core.ScalarMult
+                  Crypto.Saltine.Core.Utils
                   Crypto.Saltine.Class
   other-modules:
                 Crypto.Saltine.Internal.Util

--- a/saltine.cabal
+++ b/saltine.cabal
@@ -68,6 +68,7 @@ test-suite tests
                 OneTimeAuthProperties
                 ScalarMultProperties
                 SecretBoxProperties
+                SealedBoxProperties
                 SignProperties
                 StreamProperties
                 Util

--- a/src/Crypto/Saltine/Core/Utils.hs
+++ b/src/Crypto/Saltine/Core/Utils.hs
@@ -1,0 +1,5 @@
+module Crypto.Saltine.Core.Utils
+    (Crypto.Saltine.Internal.Util.randomVector
+    ) where
+
+import qualified Crypto.Saltine.Internal.Util

--- a/src/Crypto/Saltine/Internal/ByteSizes.hs
+++ b/src/Crypto/Saltine/Internal/ByteSizes.hs
@@ -35,6 +35,7 @@ module Crypto.Saltine.Internal.ByteSizes (
   multScalar,
   secretBoxKey,
   secretBoxNonce,
+  secretBoxMac,
   secretBoxZero,
   secretBoxBoxZero,
   sign,
@@ -56,7 +57,7 @@ boxPK, boxSK, boxNonce, boxZero, boxBoxZero :: Int
 boxMac, boxBeforeNM, sealedBox :: Int
 onetime, onetimeKey :: Int
 mult, multScalar :: Int
-secretBoxKey, secretBoxNonce, secretBoxZero, secretBoxBoxZero :: Int
+secretBoxKey, secretBoxNonce, secretBoxMac, secretBoxZero, secretBoxBoxZero :: Int
 sign, signPK, signSK :: Int
 streamKey, streamNonce :: Int
 hash, shorthash, shorthashKey :: Int
@@ -109,6 +110,8 @@ multScalar = fromIntegral c_crypto_scalarmult_scalarbytes
 secretBoxKey     = fromIntegral c_crypto_secretbox_keybytes
 -- | Size of a @crypto_secretbox@ nonce
 secretBoxNonce   = fromIntegral c_crypto_secretbox_noncebytes
+-- | Size of a @crypto_secretbox@ mac
+secretBoxMac     = fromIntegral c_crypto_secretbox_macbytes
 -- | Size of 0-padding prepended to messages before using
 -- @crypto_secretbox@ or after using @crypto_secretbox_open@
 secretBoxZero    = fromIntegral c_crypto_secretbox_zerobytes
@@ -185,6 +188,8 @@ foreign import ccall "crypto_secretbox_keybytes"
   c_crypto_secretbox_keybytes :: CSize
 foreign import ccall "crypto_secretbox_noncebytes"
   c_crypto_secretbox_noncebytes :: CSize
+foreign import ccall "crypto_secretbox_macbytes"
+  c_crypto_secretbox_macbytes :: CSize
 foreign import ccall "crypto_secretbox_zerobytes"
   c_crypto_secretbox_zerobytes :: CSize
 foreign import ccall "crypto_secretbox_boxzerobytes"

--- a/tests/SecretBoxProperties.hs
+++ b/tests/SecretBoxProperties.hs
@@ -16,20 +16,46 @@ rightInverseProp :: Key -> Nonce -> Message -> Bool
 rightInverseProp k n (Message bs) =
   Just bs == secretboxOpen k n (secretbox k n bs)
 
+-- | Detached ciphertext/tag can be decrypted
+rightInverseDetachedProp :: Key -> Nonce -> Message -> Bool
+rightInverseDetachedProp k n (Message bs) =
+  Just bs == uncurry (secretboxOpenDetached k n) (secretboxDetached k n bs)
+
 -- | Ciphertext cannot be decrypted if the ciphertext is perturbed
 rightInverseFailureProp :: Key -> Nonce -> Message -> Bool
 rightInverseFailureProp k n (Message bs) =
   Nothing == secretboxOpen k n (S.reverse $ secretbox k n bs)
+
+-- | Ciphertext cannot be decrypted if the tag is perturbed
+rightInverseTagFailureProp :: Key -> Nonce -> Message -> Bool
+rightInverseTagFailureProp k n (Message bs) =
+  Nothing == uncurry (secretboxOpenDetached k n) ((\(a,b) -> (a,S.reverse b)) $ secretboxDetached k n bs)
+
+-- | Ciphertext cannot be decrypted if the ciphertext is perturbed
+rightInverseFailureDetachedProp :: Key -> Nonce -> Message -> Bool
+rightInverseFailureDetachedProp k n (Message bs) =
+  Nothing == uncurry (secretboxOpenDetached k n) ((\(a,b) -> (S.reverse a, b)) $ secretboxDetached k n bs)
+  || S.length bs == 0
 
 -- | Ciphertext cannot be decrypted with a different key
 cannotDecryptKeyProp :: Key -> Key -> Nonce -> Message -> Bool
 cannotDecryptKeyProp k1 k2 n (Message bs) =
   Nothing == secretboxOpen k2 n (secretbox k1 n bs)
 
+-- | Ciphertext cannot be decrypted with a different key
+cannotDecryptKeyDetachedProp :: Key -> Key -> Nonce -> Message -> Bool
+cannotDecryptKeyDetachedProp k1 k2 n (Message bs) =
+  Nothing == uncurry (secretboxOpenDetached k2 n) (secretboxDetached k1 n bs)
+
 -- | Ciphertext cannot be decrypted with a different nonce
 cannotDecryptNonceProp :: Key -> Nonce -> Nonce -> Message -> Bool
 cannotDecryptNonceProp k n1 n2 (Message bs) =
   Nothing == secretboxOpen k n2 (secretbox k n1 bs)
+
+-- | Ciphertext cannot be decrypted with a different nonce
+cannotDecryptNonceDetachedProp :: Key -> Nonce -> Nonce -> Message -> Bool
+cannotDecryptNonceDetachedProp k n1 n2 (Message bs) =
+  Nothing == uncurry (secretboxOpenDetached k n2) (secretboxDetached k n1 bs)
 
 testSecretBox :: Test
 testSecretBox = buildTest $ do
@@ -43,16 +69,31 @@ testSecretBox = buildTest $ do
     testProperty "Can decrypt ciphertext"
     $ rightInverseProp k1 n1,
 
+    testProperty "Can decrypt ciphertext (detached)"
+    $ rightInverseDetachedProp k1 n1,
+
     testGroup "Cannot decrypt ciphertext when..." [
 
       testProperty "... ciphertext is perturbed"
       $ rightInverseFailureProp k1 n1,
 
+      testProperty "... ciphertext is perturbed (detached)"
+      $ rightInverseFailureDetachedProp k1 n1,
+
+      testProperty "... tag is perturbed (detached)"
+      $ rightInverseTagFailureProp k1 n1,
+
       testProperty "... using the wrong key"
       $ cannotDecryptKeyProp   k1 k2 n1,
 
+      testProperty "... using the wrong key (detached)"
+      $ cannotDecryptKeyDetachedProp   k1 k2 n1,
+
       testProperty "... using the wrong nonce"
-      $ cannotDecryptNonceProp k1 n1 n2
+      $ cannotDecryptNonceProp k1 n1 n2,
+
+      testProperty "... using the wrong nonce (detached"
+      $ cannotDecryptNonceDetachedProp k1 n1 n2
 
       ]
     ]


### PR DESCRIPTION
Add bindings for `crypto_secretbox_detached` and the matching `_open`.

This is forked from the prior patch that exposed `randomVector`. Can cherrypick if desired.