### PR TITLE
Add Windows install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ and [`Crypto.Saltine.Core.Box`](https://github.com/tel/saltine/blob/master/src/C
 If you can think of ways to use Haskell's type system to enforce 
 security invariants, please suggest them.
 
+To use it on Windows systems, download [a prebuild libsodium-\*-stable-mingw.tar.gz file](https://download.libsodium.org/libsodium/releases/) and copy the files in `libsodium-win64`  into the equivalent places in `C:\Program Files\Haskell Platform\*\mingw`. Then just add saltine to your cabal file and watch it go.
+
 Tested with [`libsodium-1.0.13`](https://download.libsodium.org/libsodium/releases/).
 
 Inspired by @thoughtpolice's

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ and [`Crypto.Saltine.Core.Box`](https://github.com/tel/saltine/blob/master/src/C
 If you can think of ways to use Haskell's type system to enforce 
 security invariants, please suggest them.
 
-To use it on Windows systems, download [a prebuild libsodium-\*-stable-mingw.tar.gz file](https://download.libsodium.org/libsodium/releases/) and copy the files in `libsodium-win64`  into the equivalent places in `C:\Program Files\Haskell Platform\*\mingw`. Then just add saltine to your cabal file and watch it go.
+To use it on Windows systems, download 
+[a prebuild libsodium-\*-stable-mingw.tar.gz file](https://download.libsodium.org/libsodium/releases/) 
+and copy the files in `libsodium-win64`  into the equivalent places 
+in `C:\Program Files\Haskell Platform\*\mingw`. Then just add saltine 
+to your cabal file and watch it go.
 
 Tested with [`libsodium-1.0.13`](https://download.libsodium.org/libsodium/releases/).
 


### PR DESCRIPTION
It's non trivial to install libsodium and saltine on Windows, since you have to install the files in a certain place which isn't documented anywhere. This should help someone.