### PR TITLE
Add the generichash function

### DIFF
--- a/src/Crypto/Saltine/Core/Hash.hs
+++ b/src/Crypto/Saltine/Core/Hash.hs
@@ -36,9 +36,9 @@
 -- alternatives that inspire satisfactory levels of confidence. One
 -- can hope that NIST's SHA-3 competition will improve the situation.
 --
--- Sodium includes an implementation of the Blake2 hash
--- (<https://blake2.net/>) but since this is not standard NaCl nor was
--- Blake2 selected to be SHA-3 the library doesn't bind it.
+-- Sodium includes an implementation of the Blake2b hash function
+-- (<https://blake2.net/>) and is bound here as the 'generichash'
+-- function.
 --
 -- This is version 2010.08.30 of the hash.html web page. Information
 -- about SipHash has been added.

--- a/src/Crypto/Saltine/Internal/ByteSizes.hs
+++ b/src/Crypto/Saltine/Internal/ByteSizes.hs
@@ -46,7 +46,9 @@ module Crypto.Saltine.Internal.ByteSizes (
   streamNonce,
   hash,
   shorthash,
-  shorthashKey
+  shorthashKey,
+  generichashOutLenMax,
+  generichashKeyLenMax
   ) where
 
 import Foreign.C
@@ -62,7 +64,7 @@ secretBoxKey, secretBoxNonce, secretBoxMac, secretBoxZero, secretBoxBoxZero :: I
 sign, signPK, signSK :: Int
 streamKey, streamNonce :: Int
 hash, shorthash, shorthashKey :: Int
-
+generichashOutLenMax, generichashKeyLenMax :: Int
 
 -- Authentication
 -- | Size of a @crypto_auth@ authenticator.
@@ -148,6 +150,12 @@ shorthash    = fromIntegral c_crypto_shorthash_bytes
 -- | The size of a hashing key for the keyed hash function
 -- 'Crypto.Saltine.Internal.Hash.shorthash'.
 shorthashKey = fromIntegral c_crypto_shorthash_keybytes
+-- | The maximum output size of the generic hash function
+-- 'Crypto.Saltine.Core.Hash.generichash'
+generichashOutLenMax = fromIntegral c_crypto_generichash_bytes_max
+-- | The maximum key size of the generic hash function
+-- 'Crypto.Saltine.Core.Hash.generichash'
+generichashKeyLenMax = fromIntegral c_crypto_generichash_keybytes_max
 
 -- src/libsodium/crypto_auth/crypto_auth.c
 foreign import ccall "crypto_auth_bytes"
@@ -206,6 +214,12 @@ foreign import ccall "crypto_sign_publickeybytes"
   c_crypto_sign_publickeybytes :: CSize
 foreign import ccall "crypto_sign_secretkeybytes"
   c_crypto_sign_secretkeybytes :: CSize
+
+-- src/libsodium/crypto_generichash/crypto_generichash.c
+foreign import ccall "crypto_generichash_bytes_max"
+  c_crypto_generichash_bytes_max :: CSize
+foreign import ccall "crypto_generichash_keybytes_max"
+  c_crypto_generichash_keybytes_max :: CSize
 
 -- HARDCODED
 -- ---------

--- a/tests/HashProperties.hs
+++ b/tests/HashProperties.hs
@@ -16,6 +16,9 @@ testHash :: Test
 testHash = buildTest $ do
   shKey <- newShorthashKey
   shKey2 <- newShorthashKey
+  ghKey <- newGenerichashKey 24 >>= maybe undefined return
+  ghKey2 <- newGenerichashKey 24 >>= maybe undefined return
+  let ghOutLen = maybe undefined id $ generichashOutLen 32
 
   return $ testGroup "...Internal.Hash" [
 
@@ -29,7 +32,13 @@ testHash = buildTest $ do
     $ \(Message bs1, Message bs2) -> bs1 /= bs2 ==> shorthash shKey bs1 /= shorthash shKey bs2,
 
     testProperty "Different keys produce different shorthashes"
-    $ \(Message bs) -> shorthash shKey bs /= shorthash shKey2 bs
+    $ \(Message bs) -> shorthash shKey bs /= shorthash shKey2 bs,
+
+    testProperty "No two generic hashes are alike"
+    $ \(Message bs1, Message bs2) -> bs1 /= bs2 ==> generichash ghKey bs1 ghOutLen /= generichash ghKey bs2 ghOutLen,
+
+    testProperty "Different keys produce different generichashes"
+    $ \(Message bs) -> generichash ghKey bs ghOutLen /= generichash ghKey2 bs ghOutLen
 
     ]
 


### PR DESCRIPTION
This pull request adds support for libsodium's [generichash](https://download.libsodium.org/doc/hashing/generic_hashing#single-part-example-with-a-key) function.

As mentioned in #54 I would like this function to be added to saltine (for a project I am working on), but I understand that the maintainers of this library may not want to go in this direction. Could you please consider this and give me any feedback on this change? 