### PR TITLE
Add missing HashProperties module to cabal file

### DIFF
--- a/saltine.cabal
+++ b/saltine.cabal
@@ -72,6 +72,7 @@ test-suite tests
   other-modules:
                 AuthProperties
                 BoxProperties
+                HashProperties
                 OneTimeAuthProperties
                 ScalarMultProperties
                 SecretBoxProperties


### PR DESCRIPTION
Without this ghci (nor downstream infrastructure like nixpkgs) can compile the tests.