### PR TITLE
Expose "Signature" type

### DIFF
--- a/src/Crypto/Saltine/Core/Sign.hs
+++ b/src/Crypto/Saltine/Core/Sign.hs
@@ -40,6 +40,7 @@ import Crypto.Saltine.Internal.Sign
             , c_sign_detached
             , c_sign_verify_detached
             , SecretKey(..)
+            , Signature(..)
             , PublicKey(..)
             , Keypair(..)
             , Signature(..)


### PR DESCRIPTION
The ``Signature`` type appears to not be visible at all right now