### PR TITLE
Allow newer bytestring and text

### DIFF
--- a/saltine.cabal
+++ b/saltine.cabal
@@ -85,11 +85,11 @@ library
   default-language:   Haskell2010
   build-depends:
                 base        >= 4.5    && < 5
-              , bytestring  >= 0.10.8 && < 0.11
+              , bytestring  >= 0.10.8 && < 0.12
               , deepseq    ^>= 1.4
               , profunctors >= 5.3    && < 5.7
               , hashable
-              , text       ^>= 1.2
+              , text       ^>= 1.2 || ^>= 2.0
 
 test-suite tests
   type:    exitcode-stdio-1.0


### PR DESCRIPTION
Address issues reported on https://github.com/haskell-cryptography/cryptography-libsodium-bindings#comparison-with-other-libraries
