### PR TITLE
Fix `Show` instances formatting, and add instances for `Keypair`s

### DIFF
--- a/src/Crypto/Saltine/Internal/AEAD/AES256GCM.hs
+++ b/src/Crypto/Saltine/Internal/AEAD/AES256GCM.hs
@@ -41,7 +41,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "AEAD.AES256GCM.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "AEAD.AES256GCM.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == aead_aes256gcm_keybytes

--- a/src/Crypto/Saltine/Internal/AEAD/ChaCha20Poly1305.hs
+++ b/src/Crypto/Saltine/Internal/AEAD/ChaCha20Poly1305.hs
@@ -41,7 +41,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "AEAD.ChaCha20Poly1305.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "AEAD.ChaCha20Poly1305.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == aead_chacha20poly1305_keybytes

--- a/src/Crypto/Saltine/Internal/AEAD/ChaCha20Poly1305IETF.hs
+++ b/src/Crypto/Saltine/Internal/AEAD/ChaCha20Poly1305IETF.hs
@@ -41,7 +41,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "AEAD.ChaCha20Poly1305IETF.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "AEAD.ChaCha20Poly1305IETF.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == aead_chacha20poly1305_ietf_keybytes

--- a/src/Crypto/Saltine/Internal/AEAD/XChaCha20Poly1305.hs
+++ b/src/Crypto/Saltine/Internal/AEAD/XChaCha20Poly1305.hs
@@ -40,7 +40,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "AEAD.XChaCha20Poly1305.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "AEAD.XChaCha20Poly1305.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == aead_xchacha20poly1305_ietf_keybytes

--- a/src/Crypto/Saltine/Internal/Auth.hs
+++ b/src/Crypto/Saltine/Internal/Auth.hs
@@ -38,7 +38,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "Auth.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Auth.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == auth_keybytes

--- a/src/Crypto/Saltine/Internal/Box.hs
+++ b/src/Crypto/Saltine/Internal/Box.hs
@@ -52,7 +52,7 @@ newtype SecretKey = SK { unSK :: ByteString } deriving (Ord, Hashable, Data, Typ
 instance Eq SecretKey where
     SK a == SK b = U.compare a b
 instance Show SecretKey where
-    show k = "Box.SecretKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Box.SecretKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding SecretKey where
   decode v = if S.length v == box_secretkeybytes
@@ -67,7 +67,7 @@ newtype PublicKey = PK { unPK :: ByteString } deriving (Ord, Hashable, Data, Typ
 instance Eq PublicKey where
     PK a == PK b = U.compare a b
 instance Show PublicKey where
-    show k = "Box.PublicKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Box.PublicKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding PublicKey where
   decode v = if S.length v == box_publickeybytes
@@ -95,7 +95,7 @@ newtype CombinedKey = CK { unCK :: ByteString } deriving (Ord, Hashable, Data, T
 instance Eq CombinedKey where
     CK a == CK b = U.compare a b
 instance Show CombinedKey where
-    show k = "Box.CombinedKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Box.CombinedKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding CombinedKey where
   decode v = if S.length v == box_beforenmbytes

--- a/src/Crypto/Saltine/Internal/Box.hs
+++ b/src/Crypto/Saltine/Internal/Box.hs
@@ -87,6 +87,9 @@ instance Eq Keypair where
     kp1 == kp2 = U.compare (encode $ secretKey kp1) (encode $ secretKey kp2)
             !&&! U.compare (encode $ publicKey kp1) (encode $ publicKey kp2)
 
+instance Show Keypair where
+    show k = "Box.Keypair {secretKey = " <> show (secretKey k) <> ", publicKey = " <> show (publicKey k) <> "}"
+
 instance Hashable Keypair
 instance NFData   Keypair
 

--- a/src/Crypto/Saltine/Internal/Hash.hs
+++ b/src/Crypto/Saltine/Internal/Hash.hs
@@ -43,7 +43,7 @@ newtype ShorthashKey = ShK { unShK :: ByteString } deriving (Ord, Hashable, Data
 instance Eq ShorthashKey where
     ShK a == ShK b = U.compare a b
 instance Show ShorthashKey where
-    show k = "Hash.ShorthashKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Hash.ShorthashKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 -- | Used for our `Show` instances
 nullShKey :: ShorthashKey
@@ -73,7 +73,7 @@ newtype GenerichashKey = GhK { unGhK :: ByteString } deriving (Ord, Hashable, Da
 instance Eq GenerichashKey where
     GhK a == GhK b = U.compare a b
 instance Show GenerichashKey where
-    show k = "Hash.GenerichashKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Hash.GenerichashKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding GenerichashKey where
   decode v = if S.length v <= generichash_keybytes_max

--- a/src/Crypto/Saltine/Internal/OneTimeAuth.hs
+++ b/src/Crypto/Saltine/Internal/OneTimeAuth.hs
@@ -38,7 +38,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "OneTimeAuth.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "OneTimeAuth.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == onetimeauth_keybytes

--- a/src/Crypto/Saltine/Internal/SecretBox.hs
+++ b/src/Crypto/Saltine/Internal/SecretBox.hs
@@ -45,7 +45,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "SecretBox.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "SecretBox.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == secretbox_keybytes

--- a/src/Crypto/Saltine/Internal/Sign.hs
+++ b/src/Crypto/Saltine/Internal/Sign.hs
@@ -44,7 +44,7 @@ newtype SecretKey = SK { unSK :: ByteString } deriving (Ord, Hashable, Data, Typ
 instance Eq SecretKey where
     SK a == SK b = U.compare a b
 instance Show SecretKey where
-    show k = "Sign.SecretKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Sign.SecretKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding SecretKey where
   decode v = if S.length v == sign_secretkeybytes
@@ -59,7 +59,7 @@ newtype PublicKey = PK { unPK :: ByteString } deriving (Ord, Data, Typeable, Has
 instance Eq PublicKey where
     PK a == PK b = U.compare a b
 instance Show PublicKey where
-    show k = "Sign.PublicKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Sign.PublicKey {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding PublicKey where
   decode v = if S.length v == sign_publickeybytes

--- a/src/Crypto/Saltine/Internal/Sign.hs
+++ b/src/Crypto/Saltine/Internal/Sign.hs
@@ -79,6 +79,9 @@ instance Eq Keypair where
     kp1 == kp2 = U.compare (encode $ secretKey kp1) (encode $ secretKey kp2)
             !&&! U.compare (encode $ publicKey kp1) (encode $ publicKey kp2)
 
+instance Show Keypair where
+    show k = "Sign.Keypair {secretKey = " <> show (secretKey k) <> ", publicKey = " <> show (publicKey k) <> "}"
+
 instance Hashable Keypair
 instance NFData   Keypair
 

--- a/src/Crypto/Saltine/Internal/Stream.hs
+++ b/src/Crypto/Saltine/Internal/Stream.hs
@@ -37,7 +37,7 @@ newtype Key = Key { unKey :: ByteString } deriving (Ord, Hashable, Data, Typeabl
 instance Eq Key where
     Key a == Key b = U.compare a b
 instance Show Key where
-    show k = "Stream.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "}\""
+    show k = "Stream.Key {hashesTo = \"" <> (bin2hex . shorthash nullShKey $ encode k) <> "\"}"
 
 instance IsEncoding Key where
   decode v = if S.length v == stream_keybytes


### PR DESCRIPTION
Two patches (could be cherry-picked if desired):

- On fixes the formatting of `Show` instances for various datatypes.

Before:
```
ghci> publicKey <$> newKeypair 
Box.PublicKey {hashesTo = "b67156c9c95a39d2}"
```
After:
```
ghci> publicKey <$> newKeypair 
Box.PublicKey {hashesTo = "e51d64ac0e388666"}
```
(Notice the placement of the final `}`).

- One adds `Show` instances for `Box.Keypair` and `Sign.Keypair`: their respective `secretKey` and `publicKey` fields have valid `Show` instances, so I assume it's fine to add `Show` instances for the pairs as well.

I tried to use the same approach/formatting of string form as is used for `Box.PrivateKey` etc. instead of using automatically-derived instances (which would be simpler, or course). As a result, they're not compatible with a (hypothetical) auto-derived `Read` instance or can't be copy-pasted as-is in code/a REPL.